### PR TITLE
IDAM-52 Fixing the site, caused by missing connection string.

### DIFF
--- a/NICE.Identity.Authorisation.WebAPI/appsettings.json
+++ b/NICE.Identity.Authorisation.WebAPI/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "leave this value here, but don't add a real connection string or anything else that needs securing. see here: https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?tabs=visual-studio"
+  },
   "AllowedHosts": "*",
   "Logging": {
     "RabbitMQHost": "",


### PR DESCRIPTION
undoing this change:
https://github.com/nhsevidence/identity/commit/0a56f8279c33fd69094e749940514b4b91a5d5bf#diff-0b2fa1d9e15f9ca429ccf375ed9bfd24